### PR TITLE
Add pip install functionality to yaml for api 0_1 with tests

### DIFF
--- a/examples/v0_1/inference_graph.yaml
+++ b/examples/v0_1/inference_graph.yaml
@@ -86,6 +86,9 @@ project:
       <<: *config_defaults
       <<: *env_defaults
       <<: *scaling_defaults
+      pip:
+        - nuclio-jupyter
+        - dataclasses
       env_custom:
         - name: BATCH_RESULTS_FOLDER
           value: /bigdata/batch_results

--- a/tests/test_apiv0_1.py
+++ b/tests/test_apiv0_1.py
@@ -1,0 +1,19 @@
+from iguazioig.apiv0_1 import format_pip_libraries
+
+
+def test_format_pip_libraries_no_input():
+    function = {'no pip': 1}
+    pip_string = format_pip_libraries(function)
+    assert pip_string == ['pip install v3io==0.5.0']
+
+
+def test_format_pip_libraries_normal_input():
+    function = {'pip': ['nuclio-jupyter', 'marshmallow', 'requests']}
+    pip_string = format_pip_libraries(function)
+    assert pip_string == ['pip install nuclio-jupyter marshmallow requests v3io==0.5.0']
+
+
+def test_format_pip_libraries_v3io_competing_input():
+    function = {'pip': ['nuclio-jupyter', 'marshmallow', 'requests', 'v3io==0.4.0']}
+    pip_string = format_pip_libraries(function)
+    assert pip_string == ['pip install nuclio-jupyter marshmallow requests v3io==0.5.0']


### PR DESCRIPTION
This allows users to specify a list of pip libraries in their
yaml to be installed in the function. v3io 0.5.0 is pinned and
no other library version is allowed in the function.